### PR TITLE
fastapi-cli 0.0.20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!/abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/rich-toolkit-feedstock/pr2/28a1dfd
-  - https://staging.continuum.io/pbp/fs/uvicorn-feedstock/pr9/ed6ba01

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,6 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/rich-toolkit-feedstock/pr2/28a1dfd
+  - https://staging.continuum.io/pbp/fs/uvicorn-feedstock/pr9/ed6ba01

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,17 +34,20 @@ requirements:
 test:
   imports:
     - fastapi_cli
+  source_files:
+    - tests
   requires:
     - pip
     - pytest >=4.4.0,<9.0.0
     # Disabling fastapi because it's a circular dependency.
-    #- fastapi
+    - fastapi
   commands:
     - pip check
     - fastapi --help
     - fastapi --version
     - fastapi dev --help
     - fastapi run --help
+    - pytest tests -vv
 
 about:
   home: https://github.com/fastapi/fastapi-cli

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ test:
     - pip
     - pytest >=4.4.0,<9.0.0
     # Disabling fastapi because it's a circular dependency.
-    - fastapi
+    - fastapi  # [py<314]
     # 'test_script' requires coverage to run in a subprocess, see https://github.com/fastapi/fastapi-cli/blob/0.0.20/tests/test_cli.py#L527
     - coverage >=6.2,<8.0
   commands:
@@ -49,7 +49,7 @@ test:
     - fastapi --version
     - fastapi dev --help
     - fastapi run --help
-    - pytest tests -vv
+    - pytest tests -vv  # [py<314]
 
 about:
   home: https://github.com/fastapi/fastapi-cli

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,9 @@ requirements:
     - typer >=0.15.1
     - tomli >=2.0.0  # [py<311]
     - uvicorn-standard >=0.15.0
+    # 'pydantic' is a missing runtime dependency and is not mentioned here https://github.com/fastapi/fastapi-cli/blob/0.0.20/pyproject.toml#L34-L39, 
+    # but it's used at runtime here https://github.com/fastapi/fastapi-cli/blob/0.0.20/src/fastapi_cli/cli.py#L6 
+    # and here https://github.com/fastapi/fastapi-cli/blob/0.0.20/src/fastapi_cli/config.py#L5.
     - pydantic >=2.0.0
 
 test:
@@ -34,6 +37,7 @@ test:
   requires:
     - pip
     - pytest >=4.4.0,<9.0.0
+    # Disabling fastapi because it's a circular dependency.
     #- fastapi
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ test:
     - pytest >=4.4.0,<9.0.0
     # Disabling fastapi because it's a circular dependency.
     - fastapi
+    # 'test_script' requires coverage to run in a subprocess, see https://github.com/fastapi/fastapi-cli/blob/0.0.20/tests/test_cli.py#L527
+    - coverage >=6.2,<8.0
   commands:
     - pip check
     - fastapi --help

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fastapi-cli" %}
-{% set version = "0.0.7" %}
+{% set version = "0.0.20" %}
 
 package:
   name: {{ name|lower }}
@@ -7,41 +7,51 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/fastapi_cli-{{ version }}.tar.gz
-  sha256: 02b3b65956f526412515907a0793c9094abd4bfb5457b389f645b0ea6ba3605e
+  sha256: d17c2634f7b96b6b560bc16b0035ed047d523c912011395f49f00a421692bc3a
 
 build:
+  number: 0
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - fastapi = fastapi_cli.cli:main
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python
     - pdm-backend
     - pip
   run:
-    - rich-toolkit >=0.11.1
-    - python >={{ python_min }}
-    - typer >=0.12.3
+    - python
+    - rich-toolkit >=0.14.8
+    - typer >=0.15.1
+    - tomli >=2.0.0  # [py<311]
     - uvicorn-standard >=0.15.0
+    - pydantic >=2.0.0
 
 test:
   imports:
     - fastapi_cli
+  requires:
+    - pip
+    - pytest >=4.4.0,<9.0.0
+    #- fastapi
   commands:
     - pip check
     - fastapi --help
-  requires:
-    - pip
-    - fastapi
-    - python {{ python_min }}
+    - fastapi --version
+    - fastapi dev --help
+    - fastapi run --help
 
 about:
-  home: https://github.com/tiangolo/fastapi-cli
+  home: https://github.com/fastapi/fastapi-cli
   summary: Run and manage FastAPI apps from the command line with FastAPI CLI. 🚀
+  description: |
+    FastAPI CLI is a command line program fastapi that you can use to serve your FastAPI app, 
+    manage your FastAPI project, and more.
+  dev_url: https://github.com/fastapi/fastapi-cli
+  doc_url: https://github.com/fastapi/fastapi-cli
   license: MIT
+  license_family: MIT
   license_file: LICENSE
 
 extra:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11877) 
- [Upstream repository](https://github.com/fastapi/fastapi-cli/tree/0.0.20)

### Explanation of changes:

- Add pydantic to runtime dependencies. It's missing in pyproject.toml. I opened an issue in the upstream Discussions https://github.com/fastapi/fastapi-cli/discussions/276

### Notes:

- fastapi requires it https://github.com/AnacondaRecipes/fastapi-feedstock/pull/8